### PR TITLE
DeadLetter actor definition

### DIFF
--- a/src/commonMain/kotlin/io/smallibs/aktor/core/ActorImpl.kt
+++ b/src/commonMain/kotlin/io/smallibs/aktor/core/ActorImpl.kt
@@ -4,8 +4,9 @@ import io.smallibs.aktor.Actor
 import io.smallibs.aktor.ActorReference
 import io.smallibs.aktor.Behavior
 import io.smallibs.aktor.Envelop
+import io.smallibs.aktor.foundation.DeadLetter
+import io.smallibs.aktor.foundation.System
 import io.smallibs.aktor.utils.NotExhaustive
-import io.smallibs.aktor.utils.exhaustive
 
 class ActorImpl<T>(override val context: ActorContextImpl<T>) : Actor<T> {
 
@@ -62,7 +63,7 @@ class ActorImpl<T>(override val context: ActorContextImpl<T>) : Actor<T> {
                 try {
                     behavior().receive(this, envelop)
                 } catch (e: NotExhaustive) {
-                    // consume for the moment - Dead letter
+                    context.self tell Core.Escalate(System.ToDeadLetter(DeadLetter.NotManaged(context.self, envelop)))
                 }
             }
         }

--- a/src/commonMain/kotlin/io/smallibs/aktor/core/Core.kt
+++ b/src/commonMain/kotlin/io/smallibs/aktor/core/Core.kt
@@ -2,6 +2,7 @@ package io.smallibs.aktor.core
 
 import io.smallibs.aktor.*
 import io.smallibs.aktor.foundation.Stashed
+import io.smallibs.aktor.foundation.System
 import io.smallibs.aktor.utils.NotExhaustive
 import io.smallibs.aktor.utils.exhaustive
 import io.smallibs.aktor.utils.reject
@@ -12,6 +13,7 @@ object Core {
     object Live : Protocol
     object Kill : Protocol
     data class Killed(val reference: ActorReference<*>) : Protocol
+    data class Escalate(val message: Any) : Protocol
 
     object Behaviors {
 
@@ -29,6 +31,8 @@ object Core {
                     is Core.Killed -> {
                         actor.context.parent()?.let { it tell message.content }
                     }
+                    is Escalate ->
+                        actor.context.parent()?.let { it tell message.content }
                     else -> reject
                 }.exhaustive
             }

--- a/src/commonMain/kotlin/io/smallibs/aktor/core/Core.kt
+++ b/src/commonMain/kotlin/io/smallibs/aktor/core/Core.kt
@@ -37,7 +37,7 @@ object Core {
                 }.exhaustive
             }
 
-        fun <T> stashed(
+        fun <T> stashBehavior(
             coreReceiver: CoreReceiver<T>,
             behavior: ExhaustiveProtocolReceiver<T> = { _, _ -> reject.exhaustive }
         ): Behavior<T> =

--- a/src/commonMain/kotlin/io/smallibs/aktor/engine/ActorDispatcher.kt
+++ b/src/commonMain/kotlin/io/smallibs/aktor/engine/ActorDispatcher.kt
@@ -5,12 +5,10 @@ import io.smallibs.aktor.core.ActorImpl
 import io.smallibs.aktor.core.ActorReferenceImpl
 import io.smallibs.aktor.core.ActorUniverse
 
-class ActorDispatcher private constructor(private val universe: ActorUniverse, private val execution: ActorExecution) {
+class ActorDispatcher(runner: ActorRunner) {
 
-    constructor(runner: ActorRunner) : this(
-        ActorUniverse(),
-        ActorExecutionImpl(runner)
-    )
+    private val universe: ActorUniverse = ActorUniverse()
+    private val execution: ActorExecution = ActorExecutionImpl(runner)
 
     fun <T> register(reference: ActorReferenceImpl<T>, behavior: Behavior<T>): ActorImpl<T> =
         ActorImpl(reference, behavior)

--- a/src/commonMain/kotlin/io/smallibs/aktor/foundation/DeadLetter.kt
+++ b/src/commonMain/kotlin/io/smallibs/aktor/foundation/DeadLetter.kt
@@ -1,0 +1,25 @@
+package io.smallibs.aktor.foundation
+
+import io.smallibs.aktor.ActorReference
+import io.smallibs.aktor.Envelop
+import io.smallibs.aktor.ProtocolReceiver
+
+object DeadLetter {
+
+    const val name = "dead-letter"
+
+    interface Protocol
+    data class NotManaged(val reference: ActorReference<*>, val envelop: Envelop<*>) : Protocol
+
+    private fun registry(logger: (ActorReference<*>, Envelop<*>) -> Unit): ProtocolReceiver<DeadLetter.Protocol> =
+        { _, message ->
+            when (message.content) {
+                is NotManaged ->
+                    logger(message.content.reference, message.content.envelop)
+            }
+        }
+
+    fun new(logger: (ActorReference<*>, Envelop<*>) -> Unit = { r, m -> println("actor $r executes $m") }) =
+        registry(logger)
+
+}

--- a/src/commonMain/kotlin/io/smallibs/aktor/foundation/DeadLetter.kt
+++ b/src/commonMain/kotlin/io/smallibs/aktor/foundation/DeadLetter.kt
@@ -3,6 +3,9 @@ package io.smallibs.aktor.foundation
 import io.smallibs.aktor.ActorReference
 import io.smallibs.aktor.Envelop
 import io.smallibs.aktor.ProtocolReceiver
+import io.smallibs.aktor.core.Core
+import io.smallibs.aktor.utils.exhaustive
+import io.smallibs.aktor.utils.reject
 
 object DeadLetter {
 
@@ -10,16 +13,47 @@ object DeadLetter {
 
     interface Protocol
     data class NotManaged(val reference: ActorReference<*>, val envelop: Envelop<*>) : Protocol
+    data class Configure(val notifier: Notifier) : Protocol
 
-    private fun registry(logger: (ActorReference<*>, Envelop<*>) -> Unit): ProtocolReceiver<DeadLetter.Protocol> =
-        { _, message ->
+    private fun registry(notifier: Notifier): ProtocolReceiver<DeadLetter.Protocol> =
+        { actor, message ->
             when (message.content) {
                 is NotManaged ->
-                    logger(message.content.reference, message.content.envelop)
-            }
+                    notifier.notify(message.content.reference, message.content.envelop)
+                is Configure ->
+                    actor become registry(message.content.notifier)
+                else ->
+                    reject
+            }.exhaustive
         }
 
-    fun new(logger: (ActorReference<*>, Envelop<*>) -> Unit = { r, m -> println("actor $r executes $m") }) =
-        registry(logger)
+    fun new(notifier: Notifier = Notifier.default()) =
+        registry(notifier)
+
+    interface Notifier {
+
+        fun notify(reference: ActorReference<*>, envelop: Envelop<*>)
+
+        class Delegate(val notifier: (ActorReference<*>, Envelop<*>) -> Unit) : Notifier {
+            override fun notify(reference: ActorReference<*>, envelop: Envelop<*>) = notifier(reference, envelop)
+        }
+
+        companion object {
+            fun default() = Delegate { _, _ -> Unit }
+        }
+
+    }
+
+    infix fun from(system: ActorReference<*>): Bridge = Bridge { message ->
+        system tell Core.Escalate(System.ToDeadLetter(message))
+    }
+
+    class Bridge(val bridge: (Protocol) -> Unit) {
+
+        infix fun configure(notifier: (ActorReference<*>, Envelop<*>) -> Unit) =
+            bridge(Configure(DeadLetter.Notifier.Delegate(notifier)))
+
+    }
 
 }
+

--- a/src/commonMain/kotlin/io/smallibs/aktor/foundation/Directory.kt
+++ b/src/commonMain/kotlin/io/smallibs/aktor/foundation/Directory.kt
@@ -36,8 +36,8 @@ object Directory {
 
     fun new(): Behavior<Protocol> = Behavior of Directory.registry(mapOf())
 
-    infix fun from(system: ActorReference<System.Protocol>): Bridge = Bridge { message ->
-        system tell System.ToDirectory(message)
+    infix fun from(system: ActorReference<*>): Bridge = Bridge { message ->
+        system tell Core.Escalate(System.ToDirectory(message))
     }
 
     class Bridge(val bridge: (Protocol) -> Unit) {

--- a/src/commonMain/kotlin/io/smallibs/aktor/foundation/Site.kt
+++ b/src/commonMain/kotlin/io/smallibs/aktor/foundation/Site.kt
@@ -17,6 +17,11 @@ class Site(val system: ActorReference<System.Protocol>, val user: ActorReference
         when (message.content) {
             is Core.Killed ->
                 system tell message.content
+            is Core.Escalate ->
+                when (message.content.message) {
+                    is System.Protocol ->
+                        system tell message.content.message
+                }
             else ->
                 Behaviors.core(actor, message)
         }

--- a/src/commonMain/kotlin/io/smallibs/aktor/foundation/System.kt
+++ b/src/commonMain/kotlin/io/smallibs/aktor/foundation/System.kt
@@ -55,6 +55,6 @@ object System {
             }.exhaustive
         }
 
-    fun new(): Behavior<System.Protocol> = Core.Behaviors.stashed(System.core)
+    fun new(): Behavior<System.Protocol> = Core.Behaviors.stashBehavior(System.core)
 
 }

--- a/src/commonTest/kotlin/io/smallibs/aktor/foundation/DeadLetterTest.kt
+++ b/src/commonTest/kotlin/io/smallibs/aktor/foundation/DeadLetterTest.kt
@@ -1,0 +1,36 @@
+package io.smallibs.aktor.foundation
+
+import io.smallibs.aktor.ActorReference
+import io.smallibs.aktor.Aktor
+import io.smallibs.aktor.ProtocolReceiver
+import io.smallibs.aktor.utils.NotExhaustive
+import io.smallibs.utils.Await
+import kotlinx.atomicfu.AtomicRef
+import kotlinx.atomicfu.atomic
+import kotlin.test.Test
+
+class DeadLetterTest {
+
+    object TestActor {
+        interface Protocol
+        object Dummy : Protocol
+
+        val receiver: ProtocolReceiver<Protocol> = { _, _ -> throw NotExhaustive() }
+    }
+
+    @Test
+    fun shouldRetrieveARegisteredActor() {
+        val site = Aktor.new("site")
+        val directory = DeadLetter from site.system
+
+        val testReference = site.actorFor(TestActor.receiver, "test")
+
+        val atomic: AtomicRef<ActorReference<*>?> = atomic(null)
+        directory configure { reference, _ -> atomic.getAndSet(reference) }
+
+        testReference tell TestActor.Dummy
+
+        Await(5000).until { atomic.value == testReference }
+    }
+
+}


### PR DESCRIPTION
The DeadLetter actor logs unmanaged messages. This is done thanks to the Escalate core message intercepted by the Site and sent back to the systems Actor.